### PR TITLE
set recurring checkbox to readonly on edit mode

### DIFF
--- a/front_end/src/components/calendar/viewEvent.jsx
+++ b/front_end/src/components/calendar/viewEvent.jsx
@@ -402,7 +402,7 @@ const ViewEvent = (props) => {
                       <Checkbox
                         size="sm"
                         isSelected={recurring}
-                        onChange={setRecurring}
+                        readOnly
                       >
                         Recurring
                       </Checkbox>


### PR DESCRIPTION
- fixed a small bug. user shouldn't be allowed to turn a recurring event to a non-recurring event.
- prior to this change, user could uncheck the recurring box, but upon submitting the change it would still be a recurring event. 